### PR TITLE
init TestCase For CallFCAPI Get EOF

### DIFF
--- a/test_func.go
+++ b/test_func.go
@@ -1,0 +1,60 @@
+package fundconnext
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+)
+
+func (f *FundConnext) CallFcApiEOF(pass bool) error {
+	fmt.Println("Func CallFcApiEOF")
+	// Create a new mock server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Close the connection before sending any response
+		conn, _, _ := w.(http.Hijacker).Hijack()
+		conn.Close()
+	}))
+	defer mockServer.Close()
+
+	// Make a request to the mock server
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", mockServer.URL, nil)
+	// var res *http.Response
+	res, err := client.Do(req)
+	if err != nil {
+		// Check if the error is EOF
+		if strings.Contains(err.Error(), "EOF") {
+			fmt.Println("EOF error occurred")
+			retire := 3
+			for i := 1; i <= retire; i++ {
+				fmt.Println("retire count: ", i)
+				res, err = client.Do(req)
+				if i == 2 && pass {
+					res = &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(strings.NewReader("Test Response Body")),
+					}
+					err = nil
+					break
+
+				}
+				time.Sleep(time.Duration(i) * time.Second)
+			}
+			if err != nil {
+				fmt.Println("err: ", err)
+				return errors.New(io.EOF.Error())
+			}
+		} else {
+			fmt.Printf("Error: %s\n", err)
+		}
+	}
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+	fmt.Printf("Response Body: %s\n", body)
+	return nil
+}

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -1,0 +1,62 @@
+package tests
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallFCAPI(t *testing.T) {
+	testTools := SetupSuite(t, SetupOptions{})
+	defer testTools.Teardown(t)
+
+	type input struct {
+		pass bool
+	}
+
+	type expected struct {
+		Expected
+	}
+	suite := Testcase{
+		"001.Call EOF(LP-620)": {
+			Mock: &Mock{},
+			Input: input{
+				pass: false,
+			},
+			Expected: expected{
+				Expected: Expected{
+					Error: io.EOF,
+				},
+			},
+		},
+		"002.Call Success(LP-620)": {
+			Mock: &Mock{},
+			Input: input{
+				pass: true,
+			},
+			Expected: expected{
+				Expected: Expected{
+					Error: nil,
+				},
+			},
+		},
+	}
+
+	for name, tc := range suite {
+		t.Run(name, func(t *testing.T) {
+			testTools := SetupTest(t, SetupOptions{Mock: tc.Mock})
+			defer testTools.Teardown(t)
+			input := tc.Input.(input).pass
+			err := testTools.FC.CallFcApiEOF(input)
+			expected := tc.Expected.(expected)
+			if expected.Error != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, expected.Error.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -170,7 +170,6 @@ func CallFCAPI(env, token, method, fp string, body interface{}, cfg *APICallerCo
 		} else {
 			return nil, err
 		}
-		return nil, err
 	}
 
 	defer resp.Body.Close()

--- a/utils.go
+++ b/utils.go
@@ -155,6 +155,21 @@ func CallFCAPI(env, token, method, fp string, body interface{}, cfg *APICallerCo
 	resp, err := client.Do(req)
 	if err != nil {
 		cfg.Logger.Error("[Func CallFundconnextAPI] Error request failed", err)
+		if strings.Contains(err.Error(), "EOF") {
+			retire := 3
+			for i := 1; i <= retire; i++ {
+				resp, err = client.Do(req)
+				if err == nil {
+					break
+				}
+				time.Sleep(time.Duration(i) * time.Second)
+			}
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Case: ยิง Request ไป FundConnext แล้วได้รับ EOF 
Solution: แก้ไขโดยการทำ Retire ใน Func CallFCAPI และทำ TestCase จำลอง