### PR TITLE
add case call RetrieveIndividualCustomer with passportCountry

### DIFF
--- a/retrieve_individual_customer_and_account.go
+++ b/retrieve_individual_customer_and_account.go
@@ -94,8 +94,16 @@ type RetrievalAccount struct {
 	OpenOmnibusFormFlag      *bool          `json:"openOmnibusFormFlag"`
 }
 
-func (f *FundConnext) RetrieveIndividualCustomerProfileAndAccount(cardNumber string) (*RetrievalIndividualCustomerProfileAndAccount, error) {
-	url := fmt.Sprintf("/api/customer/individual/investor/profile/v5?cardNumber=%s", cardNumber)
+func (f *FundConnext) RetrieveIndividualCustomerProfileAndAccount(cardNumber, passportCountry string) (*RetrievalIndividualCustomerProfileAndAccount, error) {
+	f.cfg.Logger.Infof("[Func RetrieveIndividualCustomerProfileAndAccount] input CardNumber : %s passportCountry : %s", cardNumber, passportCountry)
+
+	url := "/api/customer/individual/investor/profile/v5"
+
+	if passportCountry != "" {
+		url = url + fmt.Sprintf("?cardNumber=%s&passportCountry=%s", cardNumber, passportCountry)
+	} else {
+		url = url + fmt.Sprintf("?cardNumber=%s", cardNumber)
+	}
 
 	out, err := f.APICall("GET", url, make([]byte, 0))
 	if err != nil {

--- a/tests/account_test.go
+++ b/tests/account_test.go
@@ -9,7 +9,7 @@ func TestAccount(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	profile, err := fc.RetrieveIndividualCustomerProfileAndAccount("1100701324225") // 1100701324225
+	profile, err := fc.RetrieveIndividualCustomerProfileAndAccount("1100701324225", "") // 1100701324225
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
เพิ่ม Case ของชาวต่างชาติ เนื่องจากถ้าไม่มีการส่งค่า PassportCountry จะไม่ได้รับข้อมูล Account ของลูกค้าจากทาง FCN
*ปัจจุบันมีการส่งแค่ Cardnumber